### PR TITLE
fix: branch protection API requires empty Contexts when using Checks

### DIFF
--- a/internal/github/repos.go
+++ b/internal/github/repos.go
@@ -101,9 +101,11 @@ func (c *Client) SetBranchProtection(ctx context.Context, repo, branch string, s
 		for i, check := range statusChecks {
 			checks[i] = &gh.RequiredStatusCheck{Context: check}
 		}
+		emptyContexts := []string{}
 		req.RequiredStatusChecks = &gh.RequiredStatusChecks{
-			Strict: branch == "dev",
-			Checks: &checks,
+			Strict:   branch == "dev",
+			Checks:   &checks,
+			Contexts: &emptyContexts,
 		}
 	}
 


### PR DESCRIPTION
Closes #14